### PR TITLE
Specify minimum Node.js and Ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source "https://rubygems.org"
+
+ruby ">= 3.2"
+
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
 # file and run `bundle install`. Run Jekyll with `bundle exec`, like so:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,5 +182,8 @@ DEPENDENCIES
   tzinfo-data
   wdm (~> 0.1)
 
+RUBY VERSION
+   ruby 3.2.6p234
+
 BUNDLED WITH
    2.5.20

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "techtribes",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0",
         "js-yaml": "^4.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "@types/node": "^22.10.2",
         "sharp": "^0.33.5",
         "uncss": "^0.17.3"
+      },
+      "engines": {
+        "node": ">=22.6.0"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "sort": "node --no-warnings --experimental-strip-types src/sort.ts",
     "images": "node --no-warnings --experimental-strip-types src/images.ts"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "Oleg Podsechin",
+  "license": "MIT",
   "description": "",
   "dependencies": {
     "cheerio": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "techtribes",
   "version": "1.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=22.6.0"
+  },
   "scripts": {
     "start": "jekyll serve --source site --livereload --host 0.0.0.0",
     "build": "jekyll build --source site",


### PR DESCRIPTION
This application requires Node.js 22.6.0 or newer and Ruby 3.2 or newer. Make npm and Bundler enforce these.