### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A sample entry looks like this:
 
 ## Development
 
-Install dendencies:
+Install dependencies:
 
 ```bash
 bundle install


### PR DESCRIPTION
## Summary
- fix minor typo in Development section of README

## Testing
- `grep -n "Install dependencies" README.md`

------
https://chatgpt.com/codex/tasks/task_e_685bdca5707483279e391df99f76f4e9