### PR TITLE
Fix inactivity check when past data is missing

### DIFF
--- a/src/scrape.ts
+++ b/src/scrape.ts
@@ -26,7 +26,7 @@ async function scrape(community: {
       const members = scraped.members;
       const target = scraped.future ? future : past;
       const data = scraped.future || scraped.past;
-      if (!scraped.future) {
+      if (!scraped.future && scraped.past) {
         const [day, month, year] = scraped.past.date.split("/");
         if (
           new Date(+year, +month - 1, +day).getTime() <


### PR DESCRIPTION
## Summary
- avoid crash when `scraped.past` is undefined during scraping

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685bde3adab08327ad40b957ea99616f