### PR TITLE
Parse PyData Helsinki JSON Feed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ The scraping system (`src/scrape.ts`) supports multiple event platforms:
 - **Meetabit.com**: `src/scrapers/meetabit.ts`
 - **Luma.ma**: `src/scrapers/luma.ts`
 - **JSON endpoints**: `src/scrapers/json.ts`
+- **JSON Feed**: `src/scrapers/jsonfeed.ts`
 
 Each scraper extracts:
 

--- a/data/communities.yml
+++ b/data/communities.yml
@@ -257,7 +257,9 @@
     - Python
     - Data Science
     - AI
-  events: https://www.meetup.com/pydatahelsinki/
+  events: https://pydata-helsinki.fi/events/
+  url: https://pydata-helsinki.fi/events.json
+  site: https://pydata-helsinki.fi/
   logo: pydata.png
 - name: PyLadies Tampere
   location: Tampere, Finland

--- a/src/scrapers/json.ts
+++ b/src/scrapers/json.ts
@@ -1,3 +1,5 @@
+import { isJsonFeed, parseJsonFeed } from "./jsonfeed.ts";
+
 export default async function scrapeUrl(events: string | URL | Request) {
   try {
     const response = await fetch(events);
@@ -10,7 +12,8 @@ export default async function scrapeUrl(events: string | URL | Request) {
     const contentType = response.headers.get("content-type");
     const isJsonResponse =
       contentType?.includes("application/json") ||
-      contentType?.includes("text/plain");
+      contentType?.includes("text/plain") ||
+      contentType?.includes("application/feed+json");
 
     if (!isJsonResponse) {
       console.warn(`Expected JSON or text but got ${contentType}: ${events}`);
@@ -18,6 +21,9 @@ export default async function scrapeUrl(events: string | URL | Request) {
     }
 
     const data = await response.json();
+
+    if (isJsonFeed(data)) return parseJsonFeed(data);
+
     const event = data.event;
 
     return {

--- a/src/scrapers/jsonfeed.test.ts
+++ b/src/scrapers/jsonfeed.test.ts
@@ -1,0 +1,29 @@
+import assert from "assert";
+import scrape, { parseJsonFeed } from "./jsonfeed.ts";
+
+const feed = {
+  version: "https://jsonfeed.org/version/1.1",
+  title: "Test feed",
+  _ext: { member_count: 42 },
+  items: [
+    { id: "a", url: "https://example.com/a", date_published: "1999-01-02T10:00:00Z" },
+    {
+      id: "b",
+      url: "https://example.com/b",
+      date_published: "1999-01-01T10:00:00Z",
+      _ext_event: { start: "2099-01-01T18:00:00Z" },
+    },
+  ],
+};
+
+const upcoming = parseJsonFeed(feed);
+assert.equal(upcoming.members, 42);
+assert.equal(upcoming.event?.link, "https://example.com/b");
+assert.equal(upcoming.event?.date, "01/01/2099");
+
+const pastOnly = parseJsonFeed({ ...feed, items: [feed.items[0]] });
+assert.equal(pastOnly.event?.date, "02/01/1999");
+
+assert.equal(parseJsonFeed({ title: "empty", items: [] }).event, null);
+
+console.log(await scrape("https://pydata-helsinki.fi/events.json"));

--- a/src/scrapers/jsonfeed.ts
+++ b/src/scrapers/jsonfeed.ts
@@ -1,0 +1,64 @@
+import { formatDate } from "../utils.ts";
+
+// JSON Feed has no standard way to represent member count or event start,
+// so read them from any _extension object (PyData Helsinki has _pydata_helsinki
+// with member_count and _pydata_helsinki_event with start)
+function extensions(object: Record<string, any>) {
+  return Object.entries(object)
+    .filter(([key, value]) => key.startsWith("_") && value && typeof value === "object")
+    .map(([, value]) => value);
+}
+
+function findMembers(feed: Record<string, any>) {
+  for (const extension of extensions(feed)) {
+    for (const key of ["member_count", "members"]) {
+      if (typeof extension[key] === "number") return extension[key];
+    }
+  }
+  return undefined;
+}
+
+function findStart(item: Record<string, any>) {
+  for (const extension of extensions(item)) {
+    for (const key of ["start", "start_date", "date"]) {
+      const date = new Date(extension[key]);
+      if (extension[key] && !isNaN(date.getTime())) return date;
+    }
+  }
+  const published = new Date(item.date_published);
+  return isNaN(published.getTime()) ? null : published;
+}
+
+export function isJsonFeed(data: any) {
+  return typeof data?.version === "string" &&
+    data.version.startsWith("https://jsonfeed.org/version/");
+}
+
+export function parseJsonFeed(feed: Record<string, any>) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const dated = (feed.items ?? [])
+    .map((item: any) => ({ item, date: findStart(item) }))
+    .filter(({ date }: any) => date)
+    .sort((a: any, b: any) => a.date.getTime() - b.date.getTime());
+
+  if (!dated.length) return { event: null, name: feed.title, members: undefined };
+
+  const { item, date } =
+    dated.find(({ date }: any) => date >= today) ?? dated[dated.length - 1];
+
+  return {
+    name: feed.title,
+    logo: feed.icon,
+    members: findMembers(feed),
+    event: {
+      date: formatDate(date),
+      link: item.url ?? item.id,
+    },
+  };
+}
+
+export default async function scrape(events: string | URL | Request) {
+  return parseJsonFeed(await (await fetch(events)).json());
+}


### PR DESCRIPTION
PyData Helsinki is preparing for an eventual move out of meetup.com
and now publishes events as JSON Feed with some extensions defined
to indicate the number of members and event dates.
