### PR TITLE
Add dedicated pages per tag and location

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,12 +90,14 @@ Communities in `data/communities.yml` require:
 - `site/` - Legacy Jekyll site source (kept for rollback; see `TODO.md`)
 - `site/_data/output.yml` - Generated event data for the legacy Jekyll site
 - `remix/` - The deployed React Router site
-  - `remix/app/routes/` - Route modules: `home.tsx` (/), `guide.tsx` (/guide), `feed[.]xml.ts` (resource route, /feed.xml), `not-found.tsx` (catch-all, prerendered as /404 and copied to 404.html)
+  - `remix/app/routes.ts` - Explicit route config (framework mode does NOT auto-discover files in `app/routes/` here; new route files must be added to this list)
+  - `remix/app/routes/` - Route modules: `home.tsx` (/), `guide.tsx` (/guide), `feed[.]xml.ts` (resource route, /feed.xml), `sitemap[.]xml.ts` (resource route, /sitemap.xml), `tags.tsx` (/tags index), `tags.$tag.tsx` (/tags/:tag), `locations.tsx` (/locations index), `locations.$country.tsx`, `locations.$country.$city.tsx`, `not-found.tsx` (catch-all, prerendered as /404 and copied to 404.html)
   - `remix/app/components/layout/` - Header, Footer, ThemeToggle
   - `remix/app/components/cards/` - `CommunityCard.tsx`
   - `remix/app/components/events/` - `EventList.tsx`
+  - `remix/app/components/pages/` - `FilterPage.tsx` (shared renderer for the tag/location leaf pages)
   - `remix/app/components/ui/` - shadcn/ui primitives (button, badge, card, input, tooltip)
-  - `remix/app/lib/` - `types.ts`, `site.ts` (site constants), `events.ts` (date/event helpers), `data.server.ts` (reads `../data/output.json`), `meta.ts` (SEO/meta helpers), `filter.ts`, `feed.ts` (RSS/Atom feed generation), `content.server.ts` (loads/renders `content/guide.md`)
+  - `remix/app/lib/` - `types.ts`, `site.ts` (site constants), `events.ts` (date/event helpers), `data.server.ts` (reads `../data/output.json`), `meta.ts` (SEO/meta + count-phrase helpers), `filter.ts` (client-side search/tag filtering), `taxonomy.ts` (tag/location slugs, grouping, URL builders), `sitemap.ts` (sitemap XML builder), `feed.ts` (RSS/Atom feed generation), `prerender-paths.server.ts` (enumerates all tag/location page paths from output.json; shared by the prerender list in `react-router.config.ts` and the sitemap route), `content.server.ts` (loads/renders `content/guide.md`)
   - `remix/app/content/guide.md` - Markdown source for the guide page
   - `remix/app/styles/prose.css` - Prose styling for rendered markdown
   - `remix/scripts/postbuild.ts` - Post-build step: copies `404/index.html` to `404.html`, writes `.nojekyll`, removes stray SPA files

--- a/docs/separate-pages-implementation.md
+++ b/docs/separate-pages-implementation.md
@@ -1,0 +1,264 @@
+# Tag & Location Pages — Implementation Plan (grounded, RR v8)
+
+Implements issue #37 as scoped in [separate-pages.md](separate-pages.md) (tag pages and
+hierarchical location pages; no combined tag×location pages). This document supersedes the
+code samples in separate-pages.md wherever they conflict with reality — that doc was written
+before the Remix rewrite landed and assumes APIs that don't exist here.
+
+## How this differs from docs/separate-pages.md
+
+| separate-pages.md assumed | Reality in `remix/` | Consequence |
+|---|---|---|
+| `getCommunities()` from `data.server.ts` | Only `getScrapeOutput()` → `{ events: CommunityEvent[] }` — community + its event are already merged | All filtering operates on `CommunityEvent[]`; a "community page" is an event-list page, same as home |
+| Remix v2: `json()`, `@remix-run/node`, `MetaFunction` | React Router v8 framework mode, plain loader returns, types from `./+types/<route>` | Use `Route.LoaderArgs` / `Route.MetaArgs`, `shouldRevalidate() { return false }` like `home.tsx` |
+| Static generation via `scripts/generate-static-routes.ts` + `remix-serve` | `ssr: false` + `prerender` in `react-router.config.ts`; **prerender accepts an async function returning paths** (verified in `@react-router/dev` config types) | Enumerate slugs directly in the prerender hook; no extra build step, no server |
+| 404 via `throw new Response(..., { status: 404 })` | RR refuses to prerender non-200 responses; GitHub Pages serves `404.html` for unknown URLs anyway | Loaders never throw for unknown slugs; only valid slugs are prerendered, everything else falls through to `404.html` |
+| Date helpers reimplemented per-route (`parseDate`) | `app/lib/events.ts` has `splitEvents()`, `eventIsoDate()`, timezone-correct `todayIso()` | Reuse them; no new date code |
+| Domain `techtribes.fi` | `SITE_URL = "https://www.techtrib.es"` (`app/lib/site.ts`) | Sitemap/canonicals use `SITE_URL` |
+| `pageMeta` hand-built per route in meta export | `app/lib/meta.ts#pageMeta()` builds the full head incl. canonical + JSON-LD graph | Filter pages call `pageMeta()` with their own path/description/graph node |
+| Caching layer (TTL map / Redis / CDN) | Everything is computed at build time on ~46 events | No caching whatsoever; delete that concern |
+
+## URL structure
+
+```
+/tags                             index: links to every tag page
+/tags/:tag                        e.g. /tags/javascript
+/locations                        index: countries with their cities
+/locations/:country               e.g. /locations/finland
+/locations/:country/:city         e.g. /locations/finland/helsinki
+/sitemap.xml                      new resource route
+```
+
+Slugs: lowercase, non-alphanumerics → `-`, trimmed (`slugify("Data Science") === "data-science"`).
+Tag matching is case-insensitive (same rule as the existing `normaliseTag` in `filter.ts`),
+so "JavaScript" and "javascript" collapse onto one page; the first-seen casing wins for display,
+mirroring what `collectTags()` already does.
+
+Current data shape (from `data/output.json`, 46 events): locations are exactly
+`Helsinki/Turku/Tampere, Finland`; ~40 distinct tags. Expected page count ≈ 45–50 — trivially cheap to prerender.
+
+## Data source decision
+
+Everything derives from `getScrapeOutput().events`. Note this means tag/location pages list
+**active** communities only (had an event in the past year) — consistent with the homepage and
+the project's stated policy. `data/communities.yml` is *not* read by the site and won't be.
+
+## New shared module: `app/lib/taxonomy.ts`
+
+Pure functions, no React/Node APIs — unit-testable like `filter.ts`:
+
+```ts
+export function slugify(s: string): string;
+export interface ParsedLocation { city: string; country: string }
+export function parseLocation(location: string): ParsedLocation | undefined; // undefined if no ", "
+
+// Canonical display name per slug (first-seen casing wins), like collectTags()
+export function collectTags(events): { tag: string; slug: string; count: number }[];   // count desc
+export function collectLocations(events): {
+  country: string; slug: string; count: number;
+  cities: { city: string; slug: string; count: number }[];
+}[];
+
+export function filterByTag(events, tagSlug): CommunityEvent[];
+export function filterByLocation(events, countrySlug, citySlug?): CommunityEvent[];
+```
+
+`collectTags` can reuse/wrap the existing `collectTags` in `filter.ts` (add slug output there or
+map over it — prefer extending `filter.ts`'s return type to avoid two competing implementations).
+
+URL builders live next to them (or in the same file):
+
+```ts
+export const tagUrl = (slug: string) => `/tags/${slug}`;
+export const locationUrl = (countrySlug: string, citySlug?: string) =>
+  citySlug ? `/locations/${countrySlug}/${citySlug}` : `/locations/${countrySlug}`;
+```
+
+## Routes
+
+Five page routes plus one resource route. The three leaf routes share so much (loader shape,
+header, related filters, upcoming/past sections) that the rendering lives in one component:
+
+```
+app/routes/tags.tsx                       index: pill links to every tag page w/ counts
+app/routes/tags.$tag.tsx                  loader only (~30 lines)
+app/routes/locations.tsx                  index: countries with nested city links
+app/routes/locations.$country.tsx
+app/routes/locations.$country.$city.tsx
+app/routes/sitemap[.]xml.ts               resource route, mirrors feed[.]xml.ts
+
+app/components/pages/FilterPage.tsx   shared renderer for the leaf pages:
+  - breadcrumb ("← Back to all communities"; on city pages also the country link;
+    on all filter pages a small "Browse by tag / by location" pair linking the indexes)
+  - h1 + muted stats line ("4 communities · 12 upcoming events")
+  - related filters (cities on tag pages; tags on location pages) as pill links w/ counts
+  - <EventList upcoming past>  ← reused wholesale, including search/tag client filter
+```
+
+Reusing `EventList` gives every filter page the full search + tag-toggling progressive
+enhancement for free, and keeps the "prerendered HTML contains everything, JS only narrows"
+model intact. The plan's bespoke Upcoming/Past sections and `FilterStats` card grid are dropped —
+counts go in the stats line instead of a dashboard grid.
+
+The index routes don't render `EventList`: header plus the pill/link lists from
+`collectTags()` / `collectLocations()`. Titles: "Browse by tag" / "Tech communities by location".
+
+### Loader pattern (identical shape in all three routes)
+
+```ts
+import type { Route } from "./+types/tags.$tag";
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const { events } = await getScrapeOutput();
+  const filtered = filterByTag(events, params.tag);        // or filterByLocation(...)
+  // Unknown slug: don't throw (can't prerender 404s). Render the not-found layout at 200;
+  // invalid URLs aren't prerendered anyway, so GH Pages serves 404.html for them.
+  const { upcoming, past } = splitEvents(filtered);
+  return {
+    found: filtered.length > 0,
+    param: params.tag,
+    upcoming, past,
+    totalCommunities: filtered.length,
+    relatedTags: ...,      // collectTags(filtered), minus current
+    relatedCities: ...,    // collectLocations(filtered) — tag pages
+    relatedCountryTags: ...// location pages
+  };
+}
+
+export function shouldRevalidate() { return false; }
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  return pageMeta({
+    title: `JavaScript communities & meetups in Finland | Techtribes`,
+    description: `${n} active JavaScript tech communities in Finland with ${m} upcoming events.`,
+    path: `/tags/${slug}`,
+    graph: [collectionPageNode(...)],  // small helper added to meta.ts (schema.org CollectionPage + ItemList)
+  });
+}
+```
+
+Display names: the loader resolves the *canonical* display spelling (e.g. `/tags/js` never exists
+because only real slugs are prerendered; `/tags/javascript` shows "JavaScript"). For locations,
+resolve city/country display names from the matched communities rather than de-slugging the URL.
+
+### Prerender enumeration
+
+`react-router.config.ts` becomes async:
+
+```ts
+export default {
+  ssr: false,
+  prerender: async () => [
+    "/", "/guide", "/404", "/feed.xml", "/sitemap.xml",
+    "/tags", "/locations",
+    ...(await getPrerenderPaths()),   // tag + country/city slugs, from app/lib/taxonomy-paths.server.ts
+  ],
+};
+```
+
+The paths helper reads `data/output.json` (same path resolution as `data.server.ts`: run from
+`remix/`). If importing TS app code from the config proves awkward, the helper duplicates only
+`slugify` + two reduce loops — acceptable, but prefer the import.
+
+### Sitemap resource route
+
+`app/routes/sitemap[.]xml.ts`, modelled on `feed[.]xml.ts`: loader returns `new Response(xml,
+{ headers: { "Content-Type": "application/xml" } })`; XML built in a pure
+`app/lib/sitemap.ts` (testable, like `feed.ts`). Includes `/`, `/guide`, the `/tags` and
+`/locations` indexes (priority 0.8), all tag pages (0.7), country (0.7) and city (0.6) pages,
+`<lastmod>` from `output.json.updated`.
+Add `<link rel="sitemap">`? Not standard — skip. Keep feed's `<link rel="alternate">` as-is.
+
+## Making tags & locations clickable
+
+**Decision: tag pills on cards become links everywhere**, including the homepage. Rationale:
+issue goal is "clickable throughout the site"; having pills toggle a hidden filter on one page
+and navigate on others is inconsistent, and the quick-filter row at the top of `EventList`
+already provides toggling. Changes:
+
+- `CommunityCard.tsx`
+  - Remove `activeTags`/`onTagClick` props and the button branch; tags render as
+    `<Link to={tagUrl(slugify(tag))}><Badge …>{tag}</Badge></Link>` always.
+  - Location text becomes `<Link to={locationUrl(country, city)}>` when `parseLocation()`
+    returns a value (falls back to plain text otherwise).
+  - `EventList.tsx`: drop the props it passes through; keep the top pill row as toggles.
+- Tests referencing `onTagClick`/`activeTags` updated accordingly.
+
+No changes to Header/Footer navigation; cross-navigation between filter pages happens via the
+"Browse by tag / by location" pair in `FilterPage` and the index pages.
+
+## SEO
+
+Every page gets the full `pageMeta()` head (canonical, OG, Twitter, RSS alternate) with
+**page-specific titles and descriptions** (confirmed requirement):
+
+```html
+<meta property="og:title" content="Tech communities in Turku"/>
+<meta property="og:description" content="Discover 4 active tech communities and meetups in Turku, Finland with 1 upcoming event."/>
+```
+
+| Page | og:title | description place |
+|---|---|---|
+| `/tags/:tag` | `{Tag} communities in Finland` | Finland |
+| `/locations/:country` | `Tech communities in {Country}` | {Country} |
+| `/locations/:country/:city` | `Tech communities in {City}` | {City}, {Country} |
+| `/tags`, `/locations` | `Browse by tag` / `Tech communities by location` | directory-style blurb |
+
+Description grammar (singular/plural; trailing clause omitted when there are no upcoming
+events):
+
+```
+Discover {n} active tech communit{n === 1 ? "y" : "ies"} and meetup{n === 1 ? "" : "s"}
+in {place}[ with {u} upcoming event{u === 1 ? "" : "s"}].
+```
+
+Implement as small pure helpers (e.g. exported from `meta.ts` or a `countPhrases.ts`) with unit
+tests covering 0/1/2 for both n and u. `<title>` is the og:title plus the site suffix
+(`… | Techtribes`) via `pageMeta()`. Additionally:
+
+- New `collectionPageGraph()` helper in `meta.ts` emits a `CollectionPage` JSON-LD node merged
+  into the page's `@graph` (same mechanism as `eventListNodes`).
+- `sitemap.xml` covers discovery of all filter pages, indexes included.
+
+## Testing
+
+Follow existing conventions (vitest, colocated `*.test.ts`, tests in `remix/test/`):
+
+1. `taxonomy.test.ts` — slugify edge cases (spaces, punctuation, unicode-lite), parseLocation
+   malformed input, collectTags casing/count ordering, filterByLocation country+city.
+2. `sitemap.test.ts` — XML well-formedness, URL set (incl. `/tags`, `/locations`) matches
+   expectations on fixture data.
+3. Description/title helper tests — singular/plural, zero-upcoming omission.
+4. Component test for `FilterPage` (found/not-found branches, breadcrumb links) mirroring
+   existing component tests.
+5. Update `CommunityCard`/`EventList` tests for the link change.
+
+Manual verification checklist (same rigour as the rewrite):
+- `npm run typecheck && npm run lint && npm test && npm run build`
+- Build output contains `tags/*/index.html`, `locations/**/index.html`, `sitemap.xml`;
+  spot-check counts against `data/output.json`.
+- `vite preview` + headless Chromium: navigate home → tag pill → tag page → city link → back;
+  search still works on filter pages; no hydration errors; dark mode unaffected.
+- Validate sitemap.xml and one page's JSON-LD.
+
+## Implementation notes (August 2026)
+
+Implemented on top of the plan above. Where reality differed, this is what happened:
+
+- **Routes are explicit.** This project defines its routes in `remix/app/routes.ts`; files in
+  `app/routes/` are NOT auto-discovered. Forgetting to register them there silently produces a
+  build without the new pages (typegen only generates `+types` for registered routes — that's
+  how you notice). All five page routes plus `sitemap.xml` are now registered.
+- **Trailing-slash canonicals.** Every page is a directory-style `index.html`, so static hosts
+  (GitHub Pages, `python -m http.server`) redirect `/tags/java` → `/tags/java/` before serving.
+  Canonical/OG URLs and sitemap `<loc>` entries therefore use `canonicalPath()` (trailing slash);
+  internal `<Link>`s stay extensionless since client-side navigation needs no redirect.
+- The stale hand-written `public/sitemap.xml` (2 URLs) was deleted; `sitemap.xml` is now built
+  from the same path enumeration as the prerender list (`prerender-paths.server.ts`), so they
+  cannot drift apart.
+- **Slug collisions** exist in principle (e.g. "C++" → `c`) but not in current data; first-seen
+  casing wins for display, matching `collectTags()`.
+- `filter.ts`'s `collectTags` was left untouched; `taxonomy.ts` wraps it with slugs.
+- CommunityCard tag pills and location text are now always `<Link>`s (homepage included); the
+  homepage's top quick-filter pill row keeps its toggle behaviour per the confirmed decision.
+- Header nav gained "Tags" / "Locations" links.

--- a/remix/app/app.css
+++ b/remix/app/app.css
@@ -6,7 +6,9 @@
 
 @theme inline {
   --font-heading: var(--font-sans);
-  --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-sans:
+    ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/remix/app/components/cards/CommunityCard.test.tsx
+++ b/remix/app/components/cards/CommunityCard.test.tsx
@@ -1,5 +1,6 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router";
 
 import { CommunityCard } from "~/components/cards/CommunityCard";
 import { makeEvent } from "../../../test/fixtures";
@@ -8,6 +9,11 @@ afterEach(() => {
   cleanup();
 });
 
+/** The card's tag/location pills are <Link>s, which need a router context. */
+function renderCard(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
 describe("CommunityCard", () => {
   it("links the name to the community's site when present", () => {
     const event = makeEvent({
@@ -15,7 +21,7 @@ describe("CommunityCard", () => {
       site: "https://helsinkijs.org",
       events: "https://meetup.com/helsinki-js",
     });
-    render(<CommunityCard event={event} />);
+    renderCard(<CommunityCard event={event} />);
     const links = screen.getAllByRole("link", { name: "Helsinki JS" });
     expect(links.some((link) => link.getAttribute("href") === "https://helsinkijs.org")).toBe(true);
   });
@@ -26,14 +32,16 @@ describe("CommunityCard", () => {
       site: undefined,
       events: "https://meetup.com/helsinki-js",
     });
-    render(<CommunityCard event={event} />);
+    renderCard(<CommunityCard event={event} />);
     const links = screen.getAllByRole("link", { name: "Helsinki JS" });
-    expect(links.some((link) => link.getAttribute("href") === "https://meetup.com/helsinki-js")).toBe(true);
+    expect(
+      links.some((link) => link.getAttribute("href") === "https://meetup.com/helsinki-js"),
+    ).toBe(true);
   });
 
   it("renders the logo as decorative, since the community name is already visible", () => {
     const event = makeEvent({ name: "Helsinki JS", logo: "helsinki-js.png" });
-    const { container } = render(<CommunityCard event={event} />);
+    const { container } = renderCard(<CommunityCard event={event} />);
     const img = container.querySelector("img");
     expect(img).toHaveAttribute("alt", "");
     expect(img).toHaveAttribute("src", "/assets/logos/helsinki-js.png");
@@ -45,7 +53,7 @@ describe("CommunityCard", () => {
       name: "Helsinki JS",
       logo: "https://example.com/logo.png",
     });
-    const { container } = render(<CommunityCard event={event} />);
+    const { container } = renderCard(<CommunityCard event={event} />);
     const img = container.querySelector("img");
     expect(img).toHaveAttribute("alt", "");
     expect(img).toHaveAttribute("src", "https://example.com/logo.png");
@@ -57,7 +65,7 @@ describe("CommunityCard", () => {
       isoDate: "2026-08-15",
       event: "https://meetup.com/helsinki-js/events/1",
     });
-    render(<CommunityCard event={event} />);
+    renderCard(<CommunityCard event={event} />);
     const time = screen.getByText("15/08/2026").closest("time");
     expect(time).toHaveAttribute("dateTime", "2026-08-15");
     const eventLink = screen.getByRole("link", { name: "15/08/2026" });
@@ -66,7 +74,7 @@ describe("CommunityCard", () => {
 
   it("renders the date as plain text (no link) when there's no event URL", () => {
     const event = makeEvent({ date: "15/08/2026", isoDate: "2026-08-15", event: "" });
-    render(<CommunityCard event={event} />);
+    renderCard(<CommunityCard event={event} />);
     expect(screen.queryByRole("link", { name: "15/08/2026" })).not.toBeInTheDocument();
     expect(screen.getByText("15/08/2026")).toBeInTheDocument();
   });
@@ -76,56 +84,71 @@ describe("CommunityCard", () => {
       location: "Helsinki, Finland",
       eventLocation: "Maria 01, Helsinki",
     });
-    render(<CommunityCard event={event} />);
+    renderCard(<CommunityCard event={event} />);
     expect(screen.getByText("Maria 01, Helsinki")).toBeInTheDocument();
     expect(screen.queryByText("Helsinki, Finland")).not.toBeInTheDocument();
   });
 
   it("falls back to location when eventLocation is absent", () => {
     const event = makeEvent({ location: "Helsinki, Finland", eventLocation: undefined });
-    render(<CommunityCard event={event} />);
+    renderCard(<CommunityCard event={event} />);
     expect(screen.getByText("Helsinki, Finland")).toBeInTheDocument();
   });
 
   it("shows the member count only when present", () => {
     const withMembers = makeEvent({ members: 1200 });
-    const { rerender } = render(<CommunityCard event={withMembers} />);
+    const { rerender } = renderCard(<CommunityCard event={withMembers} />);
     expect(screen.getByText("1200")).toBeInTheDocument();
 
     const withoutMembers = makeEvent({ members: undefined });
-    rerender(<CommunityCard event={withoutMembers} />);
+    rerender(
+      <MemoryRouter>
+        <CommunityCard event={withoutMembers} />
+      </MemoryRouter>,
+    );
     expect(screen.queryByText("1200")).not.toBeInTheDocument();
   });
 
-  it("renders tags as plain (non-interactive) spans when onTagClick is not given", () => {
-    const event = makeEvent({ tags: ["javascript", "frontend"] });
-    render(<CommunityCard event={event} />);
-    const tag = screen.getByText("javascript");
-    expect(tag.tagName).toBe("SPAN");
-    expect(screen.queryByRole("button", { name: /javascript/i })).not.toBeInTheDocument();
-  });
-
-  it("renders tags as toggle buttons with aria-pressed when onTagClick is given", () => {
-    const event = makeEvent({ tags: ["javascript", "frontend"] });
-    const onTagClick = vi.fn();
-    render(<CommunityCard event={event} onTagClick={onTagClick} activeTags={["javascript"]} />);
-
-    const active = screen.getByRole("button", { name: "Filter by javascript" });
-    expect(active).toHaveAttribute("aria-pressed", "true");
-
-    const inactive = screen.getByRole("button", { name: "Filter by frontend" });
-    expect(inactive).toHaveAttribute("aria-pressed", "false");
-
-    fireEvent.click(inactive);
-    expect(onTagClick).toHaveBeenCalledWith("frontend");
-  });
-
-  it("matches activeTags case-insensitively", () => {
-    const event = makeEvent({ tags: ["JavaScript"] });
-    render(<CommunityCard event={event} onTagClick={vi.fn()} activeTags={["javascript"]} />);
-    expect(screen.getByRole("button", { name: "Filter by JavaScript" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
+  it("renders tags as links to their tag pages", () => {
+    const event = makeEvent({ tags: ["javascript", "Data Science"] });
+    renderCard(<CommunityCard event={event} />);
+    expect(screen.getByRole("link", { name: "Communities tagged javascript" })).toHaveAttribute(
+      "href",
+      "/tags/javascript",
     );
+    expect(screen.getByRole("link", { name: "Communities tagged Data Science" })).toHaveAttribute(
+      "href",
+      "/tags/data-science",
+    );
+  });
+
+  it('links the location to its city page when it parses as "City, Country"', () => {
+    const event = makeEvent({
+      location: "Helsinki, Finland",
+      eventLocation: undefined,
+    });
+    renderCard(<CommunityCard event={event} />);
+    expect(screen.getByRole("link", { name: "Helsinki, Finland" })).toHaveAttribute(
+      "href",
+      "/locations/finland/helsinki",
+    );
+  });
+
+  it("links the displayed event location to the community's city page", () => {
+    const event = makeEvent({
+      location: "Helsinki, Finland",
+      eventLocation: "Maria 01, Helsinki",
+    });
+    renderCard(<CommunityCard event={event} />);
+    const link = screen.getByRole("link", { name: "Maria 01, Helsinki" });
+    expect(link).toHaveAttribute("href", "/locations/finland/helsinki");
+    expect(screen.queryByText("Helsinki, Finland")).not.toBeInTheDocument();
+  });
+
+  it("renders an unparseable location as plain text (no link)", () => {
+    const event = makeEvent({ location: "Online", eventLocation: undefined });
+    renderCard(<CommunityCard event={event} />);
+    expect(screen.getByText("Online")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Online" })).not.toBeInTheDocument();
   });
 });

--- a/remix/app/components/cards/CommunityCard.tsx
+++ b/remix/app/components/cards/CommunityCard.tsx
@@ -1,28 +1,26 @@
 import { Calendar, MapPin, Users } from "lucide-react";
+import { Link } from "react-router";
 
 import { Badge } from "~/components/ui/badge";
 import { Card } from "~/components/ui/card";
 import { eventIsoDate, logoUrl } from "~/lib/events";
+import { locationUrl, parseLocation, slugify, tagUrl } from "~/lib/taxonomy";
 import type { CommunityEvent } from "~/lib/types";
 import { cn } from "~/lib/utils";
 
 export interface CommunityCardProps {
   event: CommunityEvent;
-  /** Tags currently selected in the filter UI (rendered as pressed). */
-  activeTags?: string[];
-  /** When provided, tags become toggle buttons; otherwise they are plain pills. */
-  onTagClick?: (tag: string) => void;
 }
 
 /** Shared look of a tag pill. */
 const TAG_CLASS =
   "h-auto rounded-lg border-0 bg-transparent px-2.5 py-1 text-xs font-medium text-foreground ring-1 ring-blue-500/50";
 
-export function CommunityCard({ event, activeTags = [], onTagClick }: CommunityCardProps) {
+export function CommunityCard({ event }: CommunityCardProps) {
   const link = event.site ?? event.events;
   const logo = logoUrl(event.logo);
   const isoDate = eventIsoDate(event);
-  const active = new Set(activeTags.map((tag) => tag.toLowerCase()));
+  const loc = parseLocation(event.location);
 
   return (
     <Card className="group gap-0 overflow-hidden rounded-xl py-0 transition-all duration-200 hover:shadow-lg hover:ring-primary/20">
@@ -82,7 +80,16 @@ export function CommunityCard({ event, activeTags = [], onTagClick }: CommunityC
               <div className="flex flex-wrap gap-x-3 text-sm text-muted-foreground">
                 <div className="flex items-center gap-1.5">
                   <MapPin className="size-4 opacity-70" aria-hidden="true" />
-                  {event.eventLocation ?? event.location}
+                  {loc ? (
+                    <Link
+                      to={locationUrl(slugify(loc.country), slugify(loc.city))}
+                      className="transition-colors hover:text-foreground hover:underline"
+                    >
+                      {event.eventLocation ?? event.location}
+                    </Link>
+                  ) : (
+                    (event.eventLocation ?? event.location)
+                  )}
                 </div>
                 {event.members ? (
                   <div className="flex items-center gap-1.5">
@@ -102,34 +109,20 @@ export function CommunityCard({ event, activeTags = [], onTagClick }: CommunityC
             {event.tags?.length ? (
               <div className="w-full md:w-auto">
                 <div className="flex flex-wrap gap-1.5">
-                  {event.tags.map((tag) =>
-                    onTagClick ? (
+                  {event.tags.map((tag) => (
+                    <Link
+                      key={tag}
+                      to={tagUrl(slugify(tag))}
+                      aria-label={`Communities tagged ${tag}`}
+                    >
                       <Badge
-                        key={tag}
-                        asChild
                         variant="secondary"
-                        className={cn(
-                          TAG_CLASS,
-                          "cursor-pointer transition-colors hover:bg-foreground/10",
-                          active.has(tag.toLowerCase()) &&
-                            "bg-primary/10 text-primary ring-primary/30 hover:bg-primary/15",
-                        )}
+                        className={cn(TAG_CLASS, "transition-colors hover:bg-foreground/10")}
                       >
-                        <button
-                          type="button"
-                          aria-pressed={active.has(tag.toLowerCase())}
-                          aria-label={`Filter by ${tag}`}
-                          onClick={() => onTagClick(tag)}
-                        >
-                          {tag}
-                        </button>
-                      </Badge>
-                    ) : (
-                      <Badge key={tag} variant="secondary" className={TAG_CLASS}>
                         {tag}
                       </Badge>
-                    ),
-                  )}
+                    </Link>
+                  ))}
                 </div>
               </div>
             ) : null}

--- a/remix/app/components/events/EventList.tsx
+++ b/remix/app/components/events/EventList.tsx
@@ -206,12 +206,7 @@ export function EventList({ upcoming, past }: EventListProps) {
             {filteredUpcoming.length ? (
               <div className="space-y-4">
                 {filteredUpcoming.map((event) => (
-                  <CommunityCard
-                    key={eventKey(event)}
-                    event={event}
-                    activeTags={activeTags}
-                    onTagClick={toggleTag}
-                  />
+                  <CommunityCard key={eventKey(event)} event={event} />
                 ))}
               </div>
             ) : (
@@ -231,12 +226,7 @@ export function EventList({ upcoming, past }: EventListProps) {
             {filteredPast.length ? (
               <div className="space-y-4">
                 {filteredPast.map((event) => (
-                  <CommunityCard
-                    key={eventKey(event)}
-                    event={event}
-                    activeTags={activeTags}
-                    onTagClick={toggleTag}
-                  />
+                  <CommunityCard key={eventKey(event)} event={event} />
                 ))}
               </div>
             ) : (

--- a/remix/app/components/layout/Header.tsx
+++ b/remix/app/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { Code2, Rss } from "lucide-react";
+import { Code2, MapPin, Rss, Tag } from "lucide-react";
 import { Link } from "react-router";
 
 import { ThemeToggle } from "~/components/layout/ThemeToggle";
@@ -12,16 +12,24 @@ export function Header() {
         <div className="container mx-auto px-4">
           <div className="relative flex items-center justify-between py-4">
             <Link to="/" aria-label="home" className="flex items-center gap-2">
-              <img
-                src="/assets/icons/tent.svg"
-                width="24"
-                height="24"
-                className="size-6"
-                alt=""
-              />
+              <img src="/assets/icons/tent.svg" width="24" height="24" className="size-6" alt="" />
               <span className="text-xl font-bold">Techtribes</span>
             </Link>
             <div className="flex items-center gap-3">
+              <Link
+                to="/tags"
+                className="inline-flex h-9 items-center gap-2 rounded-[8px] bg-white px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-100"
+              >
+                <Tag className="size-5" aria-hidden="true" />
+                <span>Topics</span>
+              </Link>
+              <Link
+                to="/locations"
+                className="inline-flex h-9 items-center gap-2 rounded-[8px] bg-white px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-100"
+              >
+                <MapPin className="size-5" aria-hidden="true" />
+                <span>Locations</span>
+              </Link>
               <a
                 href={REPO_URL}
                 className="inline-flex h-9 items-center gap-2 rounded-[8px] bg-white px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-100"

--- a/remix/app/components/pages/FilterPage.test.tsx
+++ b/remix/app/components/pages/FilterPage.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { createRoutesStub } from "react-router";
+
+import { FilterPage } from "~/components/pages/FilterPage";
+import type { FilterPageData } from "~/components/pages/FilterPage";
+import { makeEvent } from "../../../test/fixtures";
+import { splitEvents } from "~/lib/events";
+
+afterEach(() => {
+  cleanup();
+});
+
+const events = [
+  makeEvent({ name: "Helsinki JS", tags: ["JavaScript"], location: "Helsinki, Finland" }),
+  makeEvent({ name: "Turku DevOps", tags: ["DevOps"], location: "Turku, Finland" }),
+];
+
+const base: FilterPageData = {
+  found: true,
+  crumbs: [
+    { label: "All communities", to: "/" },
+    { label: "Topics", to: "/tags" },
+    { label: "JavaScript" },
+  ],
+  heading: "JavaScript communities",
+  statsLine: "1 community · 1 upcoming event",
+  ...splitEvents(events, "2026-08-10"),
+  pagePath: "/tags/javascript",
+  pageTitle: "JavaScript communities in Finland",
+  pagePlace: "Finland",
+};
+
+function renderFilterPage(data: FilterPageData) {
+  const Stub = createRoutesStub([
+    {
+      path: "/tags/:tag",
+      Component: () => <FilterPage data={data} />,
+    },
+  ]);
+  return render(<Stub initialEntries={["/tags/javascript"]} />);
+}
+
+describe("FilterPage", () => {
+  it("renders the breadcrumb, heading and stats line", () => {
+    renderFilterPage(base);
+    expect(screen.getByRole("navigation", { name: "Breadcrumb" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "All communities" })).toHaveAttribute("href", "/");
+    expect(screen.getByRole("link", { name: "Topics" })).toHaveAttribute("href", "/tags");
+    // The leaf is plain text marked as the current page, not a link.
+    const leaf = screen
+      .getByRole("navigation", { name: "Breadcrumb" })
+      .querySelector("[aria-current='page']");
+    expect(leaf).toHaveTextContent("JavaScript");
+    expect(screen.getByRole("heading", { name: "JavaScript communities" })).toBeInTheDocument();
+    expect(screen.getByText("1 community · 1 upcoming event")).toBeInTheDocument();
+  });
+
+  it("renders the upcoming/past event lists via EventList", () => {
+    renderFilterPage(base);
+    expect(screen.getByText("Helsinki JS")).toBeInTheDocument();
+    expect(screen.getByText("Turku DevOps")).toBeInTheDocument();
+  });
+
+  it("has no related-filter section — discovery is the event list's search/filter UI", () => {
+    renderFilterPage(base);
+    expect(screen.queryByText("Related tags")).not.toBeInTheDocument();
+    expect(screen.queryByText("Browse by city")).not.toBeInTheDocument();
+  });
+
+  it("shows a not-found state for an unmatched slug instead of a list", () => {
+    renderFilterPage({
+      ...base,
+      found: false,
+      missedValue: "nonexistent",
+      upcoming: [],
+      past: [],
+    });
+    expect(screen.getByRole("heading", { name: "Nothing here (yet)" })).toBeInTheDocument();
+    expect(screen.getByText(/No communities found for/i)).toBeInTheDocument();
+    expect(screen.queryByText("JavaScript communities")).not.toBeInTheDocument();
+  });
+});

--- a/remix/app/components/pages/FilterPage.tsx
+++ b/remix/app/components/pages/FilterPage.tsx
@@ -1,0 +1,97 @@
+/**
+ * Shared renderer for the tag and location leaf pages
+ * (/tags/:tag, /locations/:country[/:city]).
+ *
+ * The three routes only differ in how they compute this data; the rendering —
+ * breadcrumb, heading + stats line, event list — lives here. Reuses <EventList>,
+ * whose search + tag-filter pills cover discovery within the page; cross-page
+ * navigation happens via the breadcrumbs and the header navbar.
+ */
+import { Link } from "react-router";
+
+import { EventList } from "~/components/events/EventList";
+import { Button } from "~/components/ui/button";
+import type { CommunityEvent } from "~/lib/types";
+
+export interface Crumb {
+  label: string;
+  to?: string;
+}
+
+export interface FilterPageData {
+  /** False when no community matches (only reachable by hand-typing a URL). */
+  found: boolean;
+  /** The unrecognised URL fragment, shown in the not-found message. */
+  missedValue?: string;
+  crumbs: Crumb[];
+  heading: string;
+  statsLine: string;
+  upcoming: CommunityEvent[];
+  past: CommunityEvent[];
+  /** Canonical path of this page, used by `meta()` for the canonical URL. */
+  pagePath: string;
+  /** Full page title without the " | Techtribes" suffix, e.g.
+   * "JavaScript communities in Finland" or "Tech communities in Turku". */
+  pageTitle: string;
+  /** The place phrase for the description sentence, e.g. "Finland" or
+   * "Turku, Finland". */
+  pagePlace: string;
+  /** For tag pages, the display name of the tag ("AI"); used in the meta
+   * description ("active AI communities"). Omitted for location pages. */
+  topic?: string;
+}
+
+export function FilterPage({ data }: { data: FilterPageData }) {
+  if (!data.found) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-6 p-6 text-center md:p-12">
+        <header className="flex max-w-sm flex-col items-center gap-3">
+          <h1 className="text-2xl font-bold">Nothing here (yet)</h1>
+          <p className="text-sm/relaxed text-muted-foreground">
+            No communities found for &ldquo;{data.missedValue}&rdquo;. It may have gone inactive
+            &mdash; only communities with events in the past year are listed.
+          </p>
+        </header>
+        <Button asChild>
+          <Link to="/">Go home</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <nav aria-label="Breadcrumb" className="flex flex-wrap items-center gap-2 text-sm">
+        {data.crumbs.map((crumb, index) => (
+          <span key={`${crumb.label}-${index}`} className="flex items-center gap-2">
+            {index > 0 ? (
+              <span aria-hidden="true" className="text-muted-foreground">
+                /
+              </span>
+            ) : null}
+            {crumb.to ? (
+              <Link
+                to={crumb.to}
+                className="text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {crumb.label}
+              </Link>
+            ) : (
+              // The leaf page itself: plain text so it reads as the trail's end.
+              <span aria-current="page" className="font-medium text-foreground">
+                {crumb.label}
+              </span>
+            )}
+          </span>
+        ))}
+      </nav>
+
+      <header className="space-y-2">
+        <h1 className="text-3xl leading-tight font-bold md:text-4xl">{data.heading}</h1>
+        <p className="text-muted-foreground">{data.statsLine}</p>
+      </header>
+
+      <EventList upcoming={data.upcoming} past={data.past} />
+    </div>
+  );
+}

--- a/remix/app/lib/meta.test.ts
+++ b/remix/app/lib/meta.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
 import type { MetaDescriptor } from "react-router";
 
-import { eventListNodes, pageMeta } from "~/lib/meta";
+import {
+  collectionPageNodes,
+  communitiesDescription,
+  eventListNodes,
+  filterStatsLine,
+  pageMeta,
+  upcomingEventsPhrase,
+} from "~/lib/meta";
+import { makeEvent } from "../../test/fixtures";
 import type { CommunityEvent } from "~/lib/types";
 import { SITE_URL } from "~/lib/site";
 
@@ -76,9 +84,9 @@ describe("pageMeta", () => {
       (m) => m.tagName === "link" && m.rel === "canonical",
     )?.href;
     expect(homeCanonical).toBe(`${SITE_URL}/`);
-    expect(guideCanonical).toBe(`${SITE_URL}/guide`);
+    expect(guideCanonical).toBe(`${SITE_URL}/guide/`);
     expect(homeCanonical).not.toBe(guideCanonical);
-    expect(byProperty(guideMeta, "og:url")?.content).toBe(`${SITE_URL}/guide`);
+    expect(byProperty(guideMeta, "og:url")?.content).toBe(`${SITE_URL}/guide/`);
   });
 });
 
@@ -166,5 +174,77 @@ describe("eventListNodes", () => {
       unknown
     >[];
     expect(graph.map((node) => node["@type"])).toEqual(["WebSite", "Organization", "ItemList"]);
+  });
+});
+
+describe("upcomingEventsPhrase", () => {
+  it.each([
+    [0, "0 upcoming events"],
+    [1, "1 upcoming event"],
+    [2, "2 upcoming events"],
+  ])("upcomingEventsPhrase(%i) -> %j", (count, expected) => {
+    expect(upcomingEventsPhrase(count)).toBe(expected);
+  });
+});
+
+describe("filterStatsLine", () => {
+  it("shows both counts when there are upcoming events", () => {
+    expect(filterStatsLine(4, 12)).toBe("4 communities · 12 upcoming events");
+  });
+
+  it("uses the singular community noun", () => {
+    expect(filterStatsLine(1, 1)).toBe("1 community · 1 upcoming event");
+  });
+
+  it("drops the upcoming part when there is nothing upcoming", () => {
+    expect(filterStatsLine(3, 0)).toBe("3 communities");
+  });
+});
+
+describe("communitiesDescription", () => {
+  it("builds the full sentence with plurals and an upcoming clause", () => {
+    expect(communitiesDescription(4, "Turku, Finland", 1)).toBe(
+      "Discover 4 active tech communities and meetups in Turku, Finland with 1 upcoming event.",
+    );
+  });
+
+  it("uses singular nouns for a single community", () => {
+    expect(communitiesDescription(1, "Finland", 2)).toBe(
+      "Discover 1 active tech community and meetup in Finland with 2 upcoming events.",
+    );
+  });
+
+  it("replaces tech with the topic for tag pages", () => {
+    expect(communitiesDescription(6, "Finland", 3, "AI")).toBe(
+      "Discover 6 active AI communities and meetups in Finland with 3 upcoming events.",
+    );
+    expect(communitiesDescription(1, "Finland", 0, "Data Engineering")).toBe(
+      "Discover 1 active Data Engineering community and meetup in Finland.",
+    );
+  });
+
+  it("omits the upcoming clause when nothing is upcoming", () => {
+    expect(communitiesDescription(7, "Finland", 0)).toBe(
+      "Discover 7 active tech communities and meetups in Finland.",
+    );
+  });
+});
+
+describe("collectionPageNodes", () => {
+  const community = makeEvent();
+
+  it("describes the page as a CollectionPage listing its communities", () => {
+    const [node] = collectionPageNodes("Tech communities in Turku", "/locations/finland/turku", [
+      community,
+    ]);
+    expect(node["@type"]).toBe("CollectionPage");
+    expect(node.url).toBe(`${SITE_URL}/locations/finland/turku/`);
+    const mainEntity = node.mainEntity as Record<string, unknown>;
+    expect(mainEntity.numberOfItems).toBe(1);
+    const items = mainEntity.itemListElement as Record<string, unknown>[];
+    const org = items[0].item as Record<string, unknown>;
+    expect(org["@type"]).toBe("Organization");
+    expect(org.name).toBe(community.name);
+    expect(org.url).toBe(community.site);
   });
 });

--- a/remix/app/lib/meta.ts
+++ b/remix/app/lib/meta.ts
@@ -25,7 +25,49 @@ export interface PageMetaOptions {
 /** A JSON-LD node inside the page's @graph. */
 type GraphNode = Record<string, unknown> & { "@type": string };
 
+// --- Count phrases (shared by filter-page stats lines and descriptions) ---
+
+/** "0 upcoming events" / "1 upcoming event" / "2 upcoming events". */
+export function upcomingEventsPhrase(count: number): string {
+  return `${count} upcoming event${count === 1 ? "" : "s"}`;
+}
+
+/** Muted stats line under a filter page's heading, e.g. "4 communities · 12 upcoming events".
+ * The upcoming part is omitted when there is nothing upcoming. Deliberately no member counts:
+ * summing members across communities is meaningless given platform overlap. */
+export function filterStatsLine(communities: number, upcoming: number): string {
+  const noun = communities === 1 ? "community" : "communities";
+  const base = `${communities} ${noun}`;
+  return upcoming > 0 ? `${base} · ${upcomingEventsPhrase(upcoming)}` : base;
+}
+
+/** Description sentence for tag/location pages, e.g. "Discover 4 active tech communities and
+ * meetups in Turku, Finland with 1 upcoming event." When `topic` is given it replaces "tech"
+ * ("Discover 6 active AI communities …"). The upcoming clause is omitted when there is nothing
+ * upcoming; singular/plural are handled throughout. */
+export function communitiesDescription(
+  communityCount: number,
+  place: string,
+  upcomingCount: number,
+  topic?: string,
+): string {
+  const communityNoun = communityCount === 1 ? "community" : "communities";
+  const meetupNoun = communityCount === 1 ? "meetup" : "meetups";
+  const kind = topic ? `${topic} ` : "tech ";
+  const upcoming = upcomingCount > 0 ? ` with ${upcomingEventsPhrase(upcomingCount)}` : "";
+  return `Discover ${communityCount} active ${kind}${communityNoun} and ${meetupNoun} in ${place}${upcoming}.`;
+}
+
 const OG_IMAGE_URL = `${SITE_URL}${OG_IMAGE_PATH}`;
+
+/**
+ * Every page is prerendered as a directory-style index.html, so static hosts
+ * serve `path` only after redirecting to `path/`. Canonical/OG URLs therefore
+ * use the trailing-slash form — the URL a visitor (and search engine) ends up on.
+ */
+export function canonicalPath(path: string): string {
+  return path === "/" || path.endsWith("/") ? path : `${path}/`;
+}
 
 /** Build the complete list of meta descriptors for a page. */
 export function pageMeta({
@@ -34,7 +76,7 @@ export function pageMeta({
   path,
   graph = [],
 }: PageMetaOptions): MetaDescriptor[] {
-  const url = `${SITE_URL}${path}`;
+  const url = `${SITE_URL}${canonicalPath(path)}`;
   return [
     { title },
     { name: "description", content: description },
@@ -89,6 +131,37 @@ export function pageMeta({
           },
           ...graph,
         ],
+      },
+    },
+  ];
+}
+
+/**
+ * @graph nodes describing a filter page as a schema.org CollectionPage whose
+ * item list is the set of listed communities.
+ */
+export function collectionPageNodes(
+  name: string,
+  path: string,
+  communities: CommunityEvent[],
+): GraphNode[] {
+  return [
+    {
+      "@type": "CollectionPage",
+      name,
+      url: `${SITE_URL}${canonicalPath(path)}`,
+      mainEntity: {
+        "@type": "ItemList",
+        numberOfItems: communities.length,
+        itemListElement: communities.map((event, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          item: {
+            "@type": "Organization",
+            name: event.name,
+            url: event.site ?? event.events,
+          },
+        })),
       },
     },
   ];

--- a/remix/app/lib/prerender-paths.server.ts
+++ b/remix/app/lib/prerender-paths.server.ts
@@ -1,0 +1,26 @@
+/**
+ * Server-only helper enumerating every tag and location page path from the
+ * scraped data. Used by both the prerender list in react-router.config.ts and
+ * the sitemap.xml route, so the two can never drift apart.
+ *
+ * Runs in Node at build time; all npm scripts run from `remix/`, so
+ * data.server.ts's cwd-based path resolution applies here too.
+ */
+import { getScrapeOutput } from "./data.server";
+import type { SitemapEntry } from "./sitemap";
+import { collectLocations, collectTagsWithSlugs, locationUrl, tagUrl } from "./taxonomy";
+
+export async function enumerateFilterPaths(): Promise<SitemapEntry[]> {
+  const { events } = await getScrapeOutput();
+  const entries: SitemapEntry[] = collectTagsWithSlugs(events).map(({ slug }) => ({
+    path: tagUrl(slug),
+    priority: 0.7,
+  }));
+  for (const country of collectLocations(events)) {
+    entries.push({ path: locationUrl(country.slug), priority: 0.7 });
+    for (const city of country.cities) {
+      entries.push({ path: locationUrl(country.slug, city.slug), priority: 0.6 });
+    }
+  }
+  return entries;
+}

--- a/remix/app/lib/sitemap.test.ts
+++ b/remix/app/lib/sitemap.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSitemap } from "~/lib/sitemap";
+
+describe("buildSitemap", () => {
+  it("builds a valid document with loc, lastmod and priority per entry", () => {
+    const xml = buildSitemap(
+      [
+        { path: "/", priority: 1 },
+        { path: "/tags/javascript", priority: 0.7 },
+      ],
+      { siteUrl: "https://www.techtrib.es", lastmod: "2026-08-15" },
+    );
+    expect(xml).toContain(`<?xml version="1.0" encoding="UTF-8"?>`);
+    expect(xml).toContain(`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`);
+    expect(xml).toContain("<loc>https://www.techtrib.es/</loc>");
+    expect(xml).toContain("<lastmod>2026-08-15</lastmod>");
+    expect(xml).toContain("<priority>1.0</priority>");
+    expect(xml).toContain("<loc>https://www.techtrib.es/tags/javascript/</loc>");
+    expect(xml).toContain("<priority>0.7</priority>");
+    expect(xml.trimEnd().endsWith("</urlset>")).toBe(true);
+  });
+
+  it("omits lastmod when not given", () => {
+    const xml = buildSitemap([{ path: "/", priority: 1 }], { siteUrl: "https://x.example" });
+    expect(xml).not.toContain("<lastmod>");
+  });
+
+  it("escapes XML-special characters in URLs", () => {
+    const xml = buildSitemap([{ path: "/tags/a&b<c>", priority: 0.5 }], {
+      siteUrl: "https://x.example",
+    });
+    expect(xml).toContain("<loc>https://x.example/tags/a&amp;b&lt;c&gt;/</loc>");
+    expect(xml).not.toContain("a&b<c>");
+  });
+});

--- a/remix/app/lib/sitemap.ts
+++ b/remix/app/lib/sitemap.ts
@@ -1,0 +1,36 @@
+/**
+ * Sitemap XML builder for the sitemap.xml resource route.
+ * Pure and testable, like feed.ts.
+ */
+
+export interface SitemapEntry {
+  /** Absolute path starting with "/", e.g. "/tags/javascript". */
+  path: string;
+  /** Sitemap priority between 0 and 1. */
+  priority: number;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+/** Build a complete sitemap XML document from ordered entries. Directory-style
+ * paths get the trailing-slash form that static hosts actually serve. */
+export function buildSitemap(
+  entries: SitemapEntry[],
+  options: { siteUrl: string; lastmod?: string },
+): string {
+  const urls = entries.map(({ path, priority }) => {
+    const loc = path === "/" || path.endsWith("/") ? path : `${path}/`;
+    const lines = [`<loc>${escapeXml(options.siteUrl + loc)}</loc>`];
+    if (options.lastmod) lines.push(`<lastmod>${escapeXml(options.lastmod)}</lastmod>`);
+    lines.push(`<priority>${priority.toFixed(1)}</priority>`);
+    return `  <url>\n    ${lines.join("\n    ")}\n  </url>`;
+  });
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join("\n")}\n</urlset>\n`;
+}

--- a/remix/app/lib/taxonomy.test.ts
+++ b/remix/app/lib/taxonomy.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import { makeEvent } from "../../test/fixtures";
+import {
+  canonicalTagName,
+  collectLocations,
+  collectTagsWithSlugs,
+  filterByLocation,
+  filterByTag,
+  locationUrl,
+  parseLocation,
+  slugify,
+  tagUrl,
+} from "~/lib/taxonomy";
+
+describe("slugify", () => {
+  it.each([
+    ["JavaScript", "javascript"],
+    ["Data Science", "data-science"],
+    ["Node.js", "node-js"],
+    ["C++", "c"],
+    ["  Leading and trailing  ", "leading-and-trailing"],
+    ["Multiple---dashes & such", "multiple-dashes-such"],
+    ["", ""],
+  ])("slugify(%j) -> %j", (input, expected) => {
+    expect(slugify(input)).toBe(expected);
+  });
+});
+
+describe("parseLocation", () => {
+  it("splits a City, Country string", () => {
+    expect(parseLocation("Helsinki, Finland")).toEqual({ city: "Helsinki", country: "Finland" });
+  });
+
+  it("trims whitespace around both parts", () => {
+    expect(parseLocation("  Turku ,  Finland ")).toEqual({ city: "Turku", country: "Finland" });
+  });
+
+  it("keeps extra commas as part of the country", () => {
+    expect(parseLocation("Washington, DC, USA")).toEqual({
+      city: "Washington",
+      country: "DC, USA",
+    });
+  });
+
+  it("returns undefined for values without a country part", () => {
+    expect(parseLocation("Online")).toBeUndefined();
+    expect(parseLocation("")).toBeUndefined();
+  });
+});
+
+describe("collectTagsWithSlugs", () => {
+  const events = [
+    makeEvent({ tags: ["JavaScript", "frontend"] }),
+    makeEvent({ tags: ["javascript"] }),
+    makeEvent({ tags: ["Python"] }),
+  ];
+
+  it("counts occurrences and sorts by count descending then name", () => {
+    expect(collectTagsWithSlugs(events)).toEqual([
+      { tag: "JavaScript", slug: "javascript", count: 2 },
+      { tag: "frontend", slug: "frontend", count: 1 },
+      { tag: "Python", slug: "python", count: 1 },
+    ]);
+  });
+});
+
+describe("collectLocations", () => {
+  const events = [
+    makeEvent({ location: "Helsinki, Finland" }),
+    makeEvent({ location: "Turku, Finland" }),
+    makeEvent({ location: "Helsinki, Finland" }),
+    makeEvent({ location: "Stockholm, Sweden" }),
+    makeEvent({ location: "Remote-only" }),
+  ];
+
+  it("groups by country with nested cities, most common first", () => {
+    expect(collectLocations(events)).toEqual([
+      {
+        country: "Finland",
+        slug: "finland",
+        count: 3,
+        cities: [
+          { city: "Helsinki", slug: "helsinki", count: 2 },
+          { city: "Turku", slug: "turku", count: 1 },
+        ],
+      },
+      {
+        country: "Sweden",
+        slug: "sweden",
+        count: 1,
+        cities: [{ city: "Stockholm", slug: "stockholm", count: 1 }],
+      },
+    ]);
+  });
+
+  it("skips events without a parseable location", () => {
+    const only = collectLocations([makeEvent({ location: "Nowhere in particular" })]);
+    expect(only).toEqual([]);
+  });
+});
+
+describe("filterByTag", () => {
+  const events = [
+    makeEvent({ name: "A", tags: ["JavaScript"] }),
+    makeEvent({ name: "B", tags: ["javascript"] }),
+    makeEvent({ name: "C", tags: ["Python"] }),
+  ];
+
+  it("matches tags case-insensitively via slugs", () => {
+    const names = filterByTag(events, "JAVASCRIPT").map((e) => e.name);
+    expect(names).toEqual(["A", "B"]);
+  });
+
+  it("matches multi-word tags", () => {
+    expect(filterByTag(events, "data-science")).toEqual([]);
+    const withData = [...events, makeEvent({ name: "D", tags: ["Data Science"] })];
+    expect(filterByTag(withData, "Data-Science").map((e) => e.name)).toEqual(["D"]);
+  });
+
+  it("returns everything for an empty slug", () => {
+    expect(filterByTag(events, "")).toHaveLength(3);
+  });
+});
+
+describe("filterByLocation", () => {
+  const events = [
+    makeEvent({ name: "A", location: "Helsinki, Finland" }),
+    makeEvent({ name: "B", location: "Turku, Finland" }),
+    makeEvent({ name: "C", location: "Stockholm, Sweden" }),
+    makeEvent({ name: "D", location: "Remote-only" }),
+  ];
+
+  it("filters by country slug only", () => {
+    const names = filterByLocation(events, "finland").map((e) => e.name);
+    expect(names).toEqual(["A", "B"]);
+  });
+
+  it("filters by country and city slugs", () => {
+    const names = filterByLocation(events, "Finland", "Helsinki").map((e) => e.name);
+    expect(names).toEqual(["A"]);
+  });
+
+  it("excludes events without a parseable location", () => {
+    expect(filterByLocation(events, "remote-only")).toEqual([]);
+  });
+});
+
+describe("canonicalTagName", () => {
+  it("returns the first-seen spelling for a slug", () => {
+    const events = [makeEvent({ tags: ["JavaScript"] }), makeEvent({ tags: ["javascript"] })];
+    expect(canonicalTagName(events, "JAVASCRIPT")).toBe("JavaScript");
+  });
+
+  it("returns undefined for an unknown slug", () => {
+    expect(canonicalTagName([makeEvent()], "rust")).toBeUndefined();
+  });
+});
+
+describe("URL builders", () => {
+  it("builds tag URLs", () => {
+    expect(tagUrl("javascript")).toBe("/tags/javascript");
+  });
+
+  it("builds country and city location URLs", () => {
+    expect(locationUrl("finland")).toBe("/locations/finland");
+    expect(locationUrl("finland", "helsinki")).toBe("/locations/finland/helsinki");
+  });
+});

--- a/remix/app/lib/taxonomy.ts
+++ b/remix/app/lib/taxonomy.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure helpers for the tag and location pages (/tags, /locations).
+ * No React, no Node APIs: shared between loaders, components and unit tests.
+ */
+import type { CommunityEvent } from "./types";
+import { collectTags } from "./filter";
+
+/** Lower-case a value and collapse runs of non-alphanumerics into single dashes. */
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export interface ParsedLocation {
+  city: string;
+  country: string;
+}
+
+/**
+ * Split a "City, Country" location. Returns undefined when either part is
+ * missing; commas beyond the first stay part of the country name.
+ */
+export function parseLocation(location: string): ParsedLocation | undefined {
+  const [city, ...rest] = location.split(",").map((part) => part.trim());
+  const country = rest.join(", ");
+  if (!city || !country) return undefined;
+  return { city, country };
+}
+
+export interface TagCount {
+  /** Canonical display spelling (first spelling encountered wins, like collectTags). */
+  tag: string;
+  slug: string;
+  count: number;
+}
+
+/** Distinct tags with their slugs and occurrence counts, most common first. */
+export function collectTagsWithSlugs(events: CommunityEvent[]): TagCount[] {
+  return collectTags(events).map(({ tag, count }) => ({ tag, slug: slugify(tag), count }));
+}
+
+export interface CityCount {
+  city: string;
+  slug: string;
+  count: number;
+}
+
+export interface CountryCount {
+  country: string;
+  slug: string;
+  count: number;
+  cities: CityCount[];
+}
+
+/** Distinct countries with their cities and counts, most common first. */
+export function collectLocations(events: CommunityEvent[]): CountryCount[] {
+  const countries = new Map<string, CountryCount>();
+  for (const event of events) {
+    const loc = parseLocation(event.location);
+    if (!loc) continue;
+    const slug = slugify(loc.country);
+    let country = countries.get(slug);
+    if (!country) {
+      country = { country: loc.country, slug, count: 0, cities: [] };
+      countries.set(slug, country);
+    }
+    country.count += 1;
+    const citySlug = slugify(loc.city);
+    const city = country.cities.find((candidate) => candidate.slug === citySlug);
+    if (city) city.count += 1;
+    else country.cities.push({ city: loc.city, slug: citySlug, count: 1 });
+  }
+  const byCountThenName = <T extends { count: number }>(a: T, b: T, nameKey: keyof T) =>
+    b.count - a.count || String(a[nameKey]).localeCompare(String(b[nameKey]), "en");
+  const sorted = [...countries.values()].sort((a, b) => byCountThenName(a, b, "country"));
+  for (const country of sorted) {
+    country.cities.sort((a, b) => byCountThenName(a, b, "city"));
+  }
+  return sorted;
+}
+
+/** Communities carrying a tag whose slug matches `tagSlug` (order preserved). */
+export function filterByTag(events: CommunityEvent[], tagSlug: string): CommunityEvent[] {
+  const slug = slugify(tagSlug);
+  if (!slug) return events;
+  return events.filter((event) => (event.tags ?? []).some((tag) => slugify(tag) === slug));
+}
+
+/**
+ * Communities located in a country — and optionally a city — by slug
+ * (order preserved).
+ */
+export function filterByLocation(
+  events: CommunityEvent[],
+  countrySlug: string,
+  citySlug?: string,
+): CommunityEvent[] {
+  const country = slugify(countrySlug);
+  const city = citySlug === undefined ? undefined : slugify(citySlug);
+  return events.filter((event) => {
+    const loc = parseLocation(event.location);
+    if (!loc || slugify(loc.country) !== country) return false;
+    return city === undefined || slugify(loc.city) === city;
+  });
+}
+
+/** Canonical display spelling for a tag slug, taken from the first match. */
+export function canonicalTagName(events: CommunityEvent[], tagSlug: string): string | undefined {
+  const slug = slugify(tagSlug);
+  if (!slug) return undefined;
+  for (const event of events) {
+    for (const tag of event.tags ?? []) {
+      if (slugify(tag) === slug) return tag;
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// URL builders. Safe to import on the client.
+// ---------------------------------------------------------------------------
+
+export const TAGS_URL = "/tags";
+export const LOCATIONS_URL = "/locations";
+
+export const tagUrl = (tagSlug: string) => `${TAGS_URL}/${tagSlug}`;
+
+export const locationUrl = (countrySlug: string, citySlug?: string) =>
+  citySlug ? `${LOCATIONS_URL}/${countrySlug}/${citySlug}` : `${LOCATIONS_URL}/${countrySlug}`;

--- a/remix/app/routes.ts
+++ b/remix/app/routes.ts
@@ -4,6 +4,16 @@ export default [
   index("routes/home.tsx"),
   route("guide", "routes/guide.tsx"),
   route("feed.xml", "routes/feed[.]xml.ts"),
+  route("sitemap.xml", "routes/sitemap[.]xml.ts"),
+
+  // Tag & location pages (issue #37). Only valid slugs are prerendered;
+  // invalid ones are handled by the catch-all below (404.html in production).
+  route("tags", "routes/tags.tsx"),
+  route("tags/:tag", "routes/tags.$tag.tsx"),
+  route("locations", "routes/locations.tsx"),
+  route("locations/:country", "routes/locations.$country.tsx"),
+  route("locations/:country/:city", "routes/locations.$country.$city.tsx"),
+
   // Catch-all renders the not-found page. It is prerendered at /404 and copied
   // to build/client/404.html (see scripts/postbuild.ts) for GitHub Pages.
   route("*", "routes/not-found.tsx"),

--- a/remix/app/routes/locations.$country.$city.tsx
+++ b/remix/app/routes/locations.$country.$city.tsx
@@ -1,0 +1,72 @@
+import type { ShouldRevalidateFunctionArgs } from "react-router";
+import type { Route } from "./+types/locations.$country.$city";
+import { FilterPage, type FilterPageData } from "~/components/pages/FilterPage";
+import { getScrapeOutput } from "~/lib/data.server";
+import { splitEvents } from "~/lib/events";
+import {
+  collectionPageNodes,
+  communitiesDescription,
+  eventListNodes,
+  filterStatsLine,
+  pageMeta,
+} from "~/lib/meta";
+import { filterByLocation, locationUrl, parseLocation, slugify } from "~/lib/taxonomy";
+
+export async function loader({ params }: Route.LoaderArgs): Promise<FilterPageData> {
+  const { events } = await getScrapeOutput();
+  const countrySlug = slugify(params.country ?? "");
+  const citySlug = slugify(params.city ?? "");
+  const filtered = filterByLocation(events, countrySlug, citySlug);
+  // Resolve display names from the first match instead of de-slugging the URL.
+  const loc = parseLocation(filtered[0]?.location ?? "");
+  const cityName = loc?.city ?? params.city;
+  const countryName = loc?.country ?? params.country;
+  const { upcoming, past } = splitEvents(filtered);
+
+  return {
+    found: filtered.length > 0,
+    missedValue: params.city,
+    crumbs: [
+      { label: "All communities", to: "/" },
+      { label: "Locations", to: "/locations" },
+      { label: countryName, to: locationUrl(countrySlug) },
+      { label: cityName },
+    ],
+    heading: cityName,
+    statsLine: filterStatsLine(filtered.length, upcoming.length),
+    upcoming,
+    past,
+    pagePath: locationUrl(countrySlug, citySlug),
+    pageTitle: `Tech communities in ${cityName}`,
+    pagePlace: `${cityName}, ${countryName}`,
+  };
+}
+
+/** The loader data is static, so only refetch when the params actually change
+ * (e.g. navigating between two city pages reuses this route module). */
+export function shouldRevalidate({ currentParams, nextParams }: ShouldRevalidateFunctionArgs) {
+  return currentParams.country !== nextParams.country || currentParams.city !== nextParams.city;
+}
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  return pageMeta({
+    title: `${loaderData.pageTitle} | Techtribes`,
+    description: communitiesDescription(
+      loaderData.upcoming.length + loaderData.past.length,
+      loaderData.pagePlace,
+      loaderData.upcoming.length,
+    ),
+    path: loaderData.pagePath,
+    graph: [
+      ...collectionPageNodes(loaderData.pageTitle, loaderData.pagePath, [
+        ...loaderData.upcoming,
+        ...loaderData.past,
+      ]),
+      ...eventListNodes(loaderData.upcoming),
+    ],
+  });
+}
+
+export default function CityPage({ loaderData }: Route.ComponentProps) {
+  return <FilterPage data={loaderData} />;
+}

--- a/remix/app/routes/locations.$country.tsx
+++ b/remix/app/routes/locations.$country.tsx
@@ -1,0 +1,67 @@
+import type { ShouldRevalidateFunctionArgs } from "react-router";
+import type { Route } from "./+types/locations.$country";
+import { FilterPage, type FilterPageData } from "~/components/pages/FilterPage";
+import { getScrapeOutput } from "~/lib/data.server";
+import { splitEvents } from "~/lib/events";
+import {
+  collectionPageNodes,
+  communitiesDescription,
+  eventListNodes,
+  filterStatsLine,
+  pageMeta,
+} from "~/lib/meta";
+import { filterByLocation, locationUrl, parseLocation, slugify } from "~/lib/taxonomy";
+
+export async function loader({ params }: Route.LoaderArgs): Promise<FilterPageData> {
+  const { events } = await getScrapeOutput();
+  const countrySlug = slugify(params.country ?? "");
+  const filtered = filterByLocation(events, countrySlug);
+  const name = parseLocation(filtered[0]?.location ?? "")?.country ?? params.country;
+  const { upcoming, past } = splitEvents(filtered);
+
+  return {
+    found: filtered.length > 0,
+    missedValue: params.country,
+    crumbs: [
+      { label: "All communities", to: "/" },
+      { label: "Locations", to: "/locations" },
+      { label: name },
+    ],
+    heading: name,
+    statsLine: filterStatsLine(filtered.length, upcoming.length),
+    upcoming,
+    past,
+    pagePath: locationUrl(countrySlug),
+    pageTitle: `Tech communities in ${name}`,
+    pagePlace: name,
+  };
+}
+
+/** The loader data is static, so only refetch when the params actually change
+ * (e.g. navigating /locations/finland -> /locations/sweden reuses this module). */
+export function shouldRevalidate({ currentParams, nextParams }: ShouldRevalidateFunctionArgs) {
+  return currentParams.country !== nextParams.country;
+}
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  return pageMeta({
+    title: `${loaderData.pageTitle} | Techtribes`,
+    description: communitiesDescription(
+      loaderData.upcoming.length + loaderData.past.length,
+      loaderData.pagePlace,
+      loaderData.upcoming.length,
+    ),
+    path: loaderData.pagePath,
+    graph: [
+      ...collectionPageNodes(loaderData.pageTitle, loaderData.pagePath, [
+        ...loaderData.upcoming,
+        ...loaderData.past,
+      ]),
+      ...eventListNodes(loaderData.upcoming),
+    ],
+  });
+}
+
+export default function CountryPage({ loaderData }: Route.ComponentProps) {
+  return <FilterPage data={loaderData} />;
+}

--- a/remix/app/routes/locations.test.tsx
+++ b/remix/app/routes/locations.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { createRoutesStub } from "react-router";
+import type { ComponentProps } from "react";
+
+import LocationsIndex from "~/routes/locations";
+import type { CountryCount } from "~/lib/taxonomy";
+
+afterEach(() => {
+  cleanup();
+});
+
+const countries: CountryCount[] = [
+  {
+    country: "Finland",
+    slug: "finland",
+    count: 3,
+    cities: [
+      { city: "Helsinki", slug: "helsinki", count: 2 },
+      { city: "Turku", slug: "turku", count: 1 },
+    ],
+  },
+];
+
+function renderIndex() {
+  // The route's ComponentProps include router internals we don't care about here.
+  const props = {
+    loaderData: { countries, total: 3, totalCities: 2 },
+  } as unknown as ComponentProps<typeof LocationsIndex>;
+  const Stub = createRoutesStub([
+    {
+      path: "/locations",
+      Component: () => <LocationsIndex {...props} />,
+    },
+  ]);
+  return render(<Stub initialEntries={["/locations"]} />);
+}
+
+describe("LocationsIndex", () => {
+  it("renders the heading, intro with counts, country subheading and city grid", () => {
+    renderIndex();
+
+    expect(
+      screen.getByRole("heading", { name: "Tech communities by location" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/3 active communities in 2 cities\. Pick a city/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Finland/ })).toBeInTheDocument();
+
+    const helsinki = screen.getByRole("link", { name: /Helsinki/ });
+    expect(helsinki).toHaveAttribute("href", "/locations/finland/helsinki");
+    expect(helsinki).toHaveTextContent("2 communities");
+    expect(screen.getByRole("link", { name: /Turku/ })).toHaveAttribute(
+      "href",
+      "/locations/finland/turku",
+    );
+    expect(screen.getByText("1 community")).toBeInTheDocument();
+  });
+
+  it("links the country subheading to the country page", () => {
+    renderIndex();
+    expect(screen.getByRole("link", { name: "Finland" })).toHaveAttribute(
+      "href",
+      "/locations/finland",
+    );
+  });
+});

--- a/remix/app/routes/locations.tsx
+++ b/remix/app/routes/locations.tsx
@@ -1,0 +1,79 @@
+import type { Route } from "./+types/locations";
+import { Link } from "react-router";
+
+import { getScrapeOutput } from "~/lib/data.server";
+import { pageMeta } from "~/lib/meta";
+import { collectLocations, locationUrl, LOCATIONS_URL, type CountryCount } from "~/lib/taxonomy";
+
+export async function loader() {
+  const { events } = await getScrapeOutput();
+  const countries = collectLocations(events);
+  return {
+    countries,
+    total: events.length,
+    totalCities: countries.reduce((sum, country) => sum + country.cities.length, 0),
+  };
+}
+
+/** Baked in at build time; nothing here changes client-side. */
+export function shouldRevalidate() {
+  return false;
+}
+
+export function meta() {
+  return pageMeta({
+    title: "Tech communities by location | Techtribes",
+    description:
+      "Explore active tech communities and meetups in Finland city by city: Helsinki, Turku, Tampere and more.",
+    path: LOCATIONS_URL,
+  });
+}
+
+/** "1 community" / "2 communities". */
+function communities(count: number) {
+  return `${count} ${count === 1 ? "community" : "communities"}`;
+}
+
+export default function LocationsIndex({ loaderData }: Route.ComponentProps) {
+  const { countries, total, totalCities } = loaderData;
+  return (
+    <div className="space-y-8 pb-12">
+      <header className="space-y-2">
+        <h1 className="text-3xl leading-tight font-bold md:text-4xl">
+          Tech communities by location
+        </h1>
+        <p className="text-muted-foreground">
+          {total} active {total === 1 ? "community" : "communities"} in {totalCities}{" "}
+          {totalCities === 1 ? "city" : "cities"}. Pick a city to see its communities and upcoming
+          events.
+        </p>
+      </header>
+
+      {countries.map((country: CountryCount) => (
+        <section key={country.slug}>
+          <h2 className="mb-3 text-xl font-semibold">
+            <Link to={locationUrl(country.slug)} className="transition-colors hover:text-primary">
+              {country.country}
+            </Link>
+            <span className="ml-2 text-sm font-normal text-muted-foreground tabular-nums">
+              {communities(country.count)}
+            </span>
+          </h2>
+          <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+            {country.cities.map(({ city, slug, count }) => (
+              <li key={slug}>
+                <Link
+                  to={locationUrl(country.slug, slug)}
+                  className="block h-full rounded-xl bg-foreground/5 px-4 py-3 ring-1 ring-foreground/5 transition-all duration-200 hover:bg-foreground/10 hover:shadow-lg hover:ring-primary/20"
+                >
+                  <div className="font-medium text-foreground">{city}</div>
+                  <div className="text-sm text-muted-foreground">{communities(count)}</div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/remix/app/routes/sitemap[.]xml.ts
+++ b/remix/app/routes/sitemap[.]xml.ts
@@ -1,0 +1,25 @@
+import { enumerateFilterPaths } from "~/lib/prerender-paths.server";
+import { getScrapeOutput } from "~/lib/data.server";
+import { buildSitemap, type SitemapEntry } from "~/lib/sitemap";
+import { SITE_URL } from "~/lib/site";
+
+/**
+ * Prerendered verbatim to /sitemap.xml (like feed.xml), so no cache headers
+ * are needed — it is a static file once built.
+ */
+export async function loader() {
+  const { updated } = await getScrapeOutput();
+  const staticEntries: SitemapEntry[] = [
+    { path: "/", priority: 1 },
+    { path: "/guide", priority: 0.8 },
+    { path: "/tags", priority: 0.8 },
+    { path: "/locations", priority: 0.8 },
+  ];
+  const xml = buildSitemap([...staticEntries, ...(await enumerateFilterPaths())], {
+    siteUrl: SITE_URL,
+    lastmod: updated.slice(0, 10),
+  });
+  return new Response(xml, {
+    headers: { "Content-Type": "application/xml; charset=utf-8" },
+  });
+}

--- a/remix/app/routes/tags.$tag.tsx
+++ b/remix/app/routes/tags.$tag.tsx
@@ -1,0 +1,70 @@
+import type { ShouldRevalidateFunctionArgs } from "react-router";
+import type { Route } from "./+types/tags.$tag";
+import { FilterPage, type FilterPageData } from "~/components/pages/FilterPage";
+import { getScrapeOutput } from "~/lib/data.server";
+import { splitEvents } from "~/lib/events";
+import {
+  collectionPageNodes,
+  communitiesDescription,
+  eventListNodes,
+  filterStatsLine,
+  pageMeta,
+} from "~/lib/meta";
+import { canonicalTagName, filterByTag, slugify, tagUrl } from "~/lib/taxonomy";
+
+export async function loader({ params }: Route.LoaderArgs): Promise<FilterPageData> {
+  const { events } = await getScrapeOutput();
+  const tagSlug = slugify(params.tag ?? "");
+  const filtered = filterByTag(events, tagSlug);
+  const name = canonicalTagName(filtered, tagSlug) ?? params.tag;
+  const { upcoming, past } = splitEvents(filtered);
+
+  return {
+    found: filtered.length > 0,
+    missedValue: params.tag,
+    crumbs: [
+      { label: "All communities", to: "/" },
+      { label: "Topics", to: "/tags" },
+      { label: name },
+    ],
+    heading: `${name} communities`,
+    statsLine: filterStatsLine(filtered.length, upcoming.length),
+    upcoming,
+    past,
+    pagePath: tagUrl(tagSlug),
+    // og:title pattern: "{Tag} communities in Finland".
+    pageTitle: `${name} communities in Finland`,
+    pagePlace: "Finland",
+    topic: name,
+  };
+}
+
+/** The loader data is static, so only refetch when the params actually change
+ * (e.g. navigating /tags/azure -> /tags/devops reuses this route module). */
+export function shouldRevalidate({ currentParams, nextParams }: ShouldRevalidateFunctionArgs) {
+  return currentParams.tag !== nextParams.tag;
+}
+
+export function meta({ loaderData }: Route.MetaArgs) {
+  return pageMeta({
+    title: `${loaderData.pageTitle} | Techtribes`,
+    description: communitiesDescription(
+      loaderData.upcoming.length + loaderData.past.length,
+      loaderData.pagePlace,
+      loaderData.upcoming.length,
+      loaderData.topic,
+    ),
+    path: loaderData.pagePath,
+    graph: [
+      ...collectionPageNodes(loaderData.pageTitle, loaderData.pagePath, [
+        ...loaderData.upcoming,
+        ...loaderData.past,
+      ]),
+      ...eventListNodes(loaderData.upcoming),
+    ],
+  });
+}
+
+export default function TagPage({ loaderData }: Route.ComponentProps) {
+  return <FilterPage data={loaderData} />;
+}

--- a/remix/app/routes/tags.test.tsx
+++ b/remix/app/routes/tags.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { createRoutesStub } from "react-router";
+import type { ComponentProps } from "react";
+
+import TagsIndex from "~/routes/tags";
+
+afterEach(() => {
+  cleanup();
+});
+
+// Shape mirrors the loader's return value.
+const loaderData = {
+  tags: [
+    { tag: "JavaScript", slug: "javascript", count: 2 },
+    { tag: "Python", slug: "python", count: 1 },
+  ],
+  total: 3,
+};
+
+function renderIndex() {
+  // The route's ComponentProps include router internals we don't care about here.
+  const props = { loaderData } as unknown as ComponentProps<typeof TagsIndex>;
+  const Stub = createRoutesStub([
+    {
+      path: "/tags",
+      Component: () => <TagsIndex {...props} />,
+    },
+  ]);
+  return render(<Stub initialEntries={["/tags"]} />);
+}
+
+describe("TagsIndex", () => {
+  it("renders the heading, intro with counts, and a grid of topic links", () => {
+    renderIndex();
+
+    expect(screen.getByRole("heading", { name: "Browse by topic" })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "2 topics across 3 active communities. Pick one to see its communities and upcoming events.",
+      ),
+    ).toBeInTheDocument();
+
+    const js = screen.getByRole("link", { name: /JavaScript/ });
+    expect(js).toHaveAttribute("href", "/tags/javascript");
+    expect(js).toHaveTextContent("2 communities");
+
+    const python = screen.getByRole("link", { name: /Python/ });
+    expect(python).toHaveAttribute("href", "/tags/python");
+    expect(python).toHaveTextContent("1 community");
+  });
+
+  it("uses the singular community noun for a count of 1", () => {
+    renderIndex();
+    expect(screen.getByText("1 community")).toBeInTheDocument();
+  });
+});

--- a/remix/app/routes/tags.tsx
+++ b/remix/app/routes/tags.tsx
@@ -1,0 +1,60 @@
+import type { Route } from "./+types/tags";
+import { Link } from "react-router";
+
+import { getScrapeOutput } from "~/lib/data.server";
+import { pageMeta } from "~/lib/meta";
+import { collectTagsWithSlugs, tagUrl, type TagCount } from "~/lib/taxonomy";
+
+export async function loader() {
+  const { events } = await getScrapeOutput();
+  return { tags: collectTagsWithSlugs(events), total: events.length };
+}
+
+/** Baked in at build time; nothing here changes client-side. */
+export function shouldRevalidate() {
+  return false;
+}
+
+export function meta() {
+  return pageMeta({
+    title: "Browse by topic | Techtribes",
+    description:
+      "Explore active tech communities and meetups in Finland by technology topic: JavaScript, Python, DevOps, AI and more.",
+    path: "/tags",
+  });
+}
+
+/** "1 community" / "2 communities". */
+function communities(count: number) {
+  return `${count} ${count === 1 ? "community" : "communities"}`;
+}
+
+export default function TagsIndex({ loaderData }: Route.ComponentProps) {
+  const { tags, total } = loaderData;
+  return (
+    <div className="space-y-6 pb-12">
+      <header className="space-y-2">
+        <h1 className="text-3xl leading-tight font-bold md:text-4xl">Browse by topic</h1>
+        <p className="text-muted-foreground">
+          {tags.length} {tags.length === 1 ? "topic" : "topics"} across {total} active{" "}
+          {total === 1 ? "community" : "communities"}. Pick one to see its communities and upcoming
+          events.
+        </p>
+      </header>
+
+      <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        {tags.map(({ tag, slug, count }: TagCount) => (
+          <li key={slug}>
+            <Link
+              to={tagUrl(slug)}
+              className="block h-full rounded-xl bg-foreground/5 px-4 py-3 ring-1 ring-foreground/5 transition-all duration-200 hover:bg-foreground/10 hover:shadow-lg hover:ring-primary/20"
+            >
+              <div className="font-medium text-foreground">{tag}</div>
+              <div className="text-sm text-muted-foreground">{communities(count)}</div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/remix/public/sitemap.xml
+++ b/remix/public/sitemap.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://www.techtrib.es/</loc>
-  </url>
-  <url>
-    <loc>https://www.techtrib.es/guide</loc>
-  </url>
-</urlset>

--- a/remix/react-router.config.ts
+++ b/remix/react-router.config.ts
@@ -1,16 +1,28 @@
 import type { Config } from "@react-router/dev/config";
+import { enumerateFilterPaths } from "./app/lib/prerender-paths.server";
 
 /**
  * Static site generation: no runtime server (`ssr: false`), every route is
  * pre-rendered at build time into `build/client/`.
  *
- * - "/"       -> build/client/index.html
- * - "/guide"  -> build/client/guide/index.html
- * - "/404"    -> build/client/404/index.html (copied to 404.html by scripts/postbuild.ts
- *                so GitHub Pages serves it for unknown URLs)
- * - "/feed.xml" is a resource route (loader only) and is written verbatim.
+ * - "/", "/guide", "/404", "/tags", "/locations" and every /tags/:tag and
+ *   /locations/... page -> an index.html under build/client (the filter-page
+ *   paths are enumerated from data/output.json by prerender-paths.server.ts,
+ *   shared with the sitemap so they can never drift apart)
+ * - "/404" is copied to 404.html by scripts/postbuild.ts so GitHub Pages
+ *   serves it for unknown URLs (which also covers invalid tag/location slugs)
+ * - "/feed.xml" and "/sitemap.xml" are resource routes written verbatim.
  */
 export default {
   ssr: false,
-  prerender: ["/", "/guide", "/404", "/feed.xml"],
+  prerender: async () => [
+    "/",
+    "/guide",
+    "/404",
+    "/feed.xml",
+    "/sitemap.xml",
+    "/tags",
+    "/locations",
+    ...(await enumerateFilterPaths()).map((entry) => entry.path),
+  ],
 } satisfies Config;


### PR DESCRIPTION
Add pages like "Active Python meetups in Finland" and "Active meetups in Turku", as planned in documentation. Ping @olegp 

- New routes: /tags and /locations index pages with responsive grids, /tags/:tag and /locations/:country[/:city] leaf pages (all prerendered; paths enumerated from output.json via prerender-paths.server.ts)
- Shared lib: app/lib/taxonomy.ts (slugify, parseLocation, tag/location filtering, URL builders); sitemap.ts replaces the stale hand-written public/sitemap.xml with a generated /sitemap.xml covering every page
- Tag pills on event cards and card locations are now links to the corresponding filter pages; navbar gains Topics/Locations buttons
- Leaf pages reuse <EventList> so search/tag filtering works in-page; shouldRevalidate only skips refetching when params are unchanged (fixes stale content when navigating between filter pages)
- Per-page SEO via pageMeta(): specific titles/og/twitter descriptions with singular/plural handling, CollectionPage JSON-LD, trailing-slash canonicals matching static-host redirects
- Tests for taxonomy helpers, sitemap XML, count phrases, FilterPage and both index pages (132 total)